### PR TITLE
任务详情->右键复制去除标签名

### DIFF
--- a/AriaNg/src/scripts/controllers/task-detail.js
+++ b/AriaNg/src/scripts/controllers/task-detail.js
@@ -325,7 +325,7 @@
                 value += angular.element(element).text().trim();
             });
 
-            var info = name + ': ' + value;
+            var info = value;
             clipboard.copyText(info);
         };
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/21141423/63565917-8f866e00-c59d-11e9-9152-b746deb13713.png)
before:
```
进度: 100.00%
```

now:
```
100.00%
```

大多数使用场景下，都是将复制得到的字符串粘贴到别的地方去（如链接）， 所以基本都得手工删除掉开头的标签名

并且，我认为绝大部分用户都知道自己想要复制的是什么东西，在复制的结果前面加上标签名，我觉的是多余的